### PR TITLE
update Groovy, geb and cucumber to support Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,9 +7,9 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <geb.version>0.9.2</geb.version>
+        <geb.version>1.1.1</geb.version>
         <selenium.version>2.36.0</selenium.version>
-        <cucumber.version>1.1.5</cucumber.version>
+        <cucumber.version>1.2.5</cucumber.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>org.codehaus.groovy</groupId>
             <artifactId>groovy-all</artifactId>
-            <version>1.8.6</version>
+            <version>2.4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Hi,

Your example didn't work with Java 8. so I made some changes of the Library versions and it seems to work now.